### PR TITLE
Refactor/controller id validation

### DIFF
--- a/src/post/controller/PostController.ts
+++ b/src/post/controller/PostController.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Request, Response } from "express";
-import { Model } from "mongoose";
+import { Model, isValidObjectId } from "mongoose";
 import { PostData, PostStructure } from "../types.js";
 import { PostControllerStructure, PostRequest } from "./types.js";
 import ServerError from "../../server/ServerError/ServerError.js";
@@ -91,10 +91,10 @@ class PostController implements PostControllerStructure {
   ): Promise<void> => {
     const postId = req.params.postId;
 
-    const idLength = 24;
+    const isValidId = isValidObjectId(postId);
 
-    if (postId.length !== idLength) {
-      const error = new ServerError(406, "Id not valid");
+    if (!isValidId) {
+      const error = new ServerError(400, "Id not valid");
       next(error);
 
       return;
@@ -121,10 +121,10 @@ class PostController implements PostControllerStructure {
   ): Promise<void> => {
     const postId = req.params.postId;
 
-    const idLenght = 24;
+    const isValidId = isValidObjectId(postId);
 
-    if (postId.length !== idLenght) {
-      const error = new ServerError(406, "Id not valid");
+    if (!isValidId) {
+      const error = new ServerError(400, "Id not valid");
 
       next(error);
 

--- a/src/post/controller/__tests__/deletePost.test.ts
+++ b/src/post/controller/__tests__/deletePost.test.ts
@@ -70,8 +70,8 @@ describe("Given the deletePost method of PostController", () => {
       }),
     };
 
-    test("Then it should call the received next method with 406 'Id not valid' error", async () => {
-      const error = new ServerError(406, "Id not valid");
+    test("Then it should call the received next method with 400 'Id not valid' error", async () => {
+      const error = new ServerError(400, "Id not valid");
       const postController = new PostController(
         postModel as Model<PostStructure>,
       );
@@ -88,7 +88,7 @@ describe("Given the deletePost method of PostController", () => {
 
   describe("When it receives a request with La croqueta de la abuela Post id that is not in the database", () => {
     const req = {
-      params: { postId: "croquetas666delaabuela66" },
+      params: { postId: "863725146789243765417892" },
     } as Pick<Request, "params">;
 
     const postModel: Pick<Model<PostStructure>, "findOneAndDelete"> = {

--- a/src/post/controller/__tests__/getPostById.test.ts
+++ b/src/post/controller/__tests__/getPostById.test.ts
@@ -67,8 +67,8 @@ describe("Given the getPostById method of PostController", () => {
         exec: jest.fn().mockResolvedValue(null),
       }),
     };
-    test("Then it should call the received next method with 406, 'Id not valid' error", async () => {
-      const error = new ServerError(406, "Id not valid");
+    test("Then it should call the received next method with 400, 'Id not valid' error", async () => {
+      const error = new ServerError(400, "Id not valid");
       const postController = new PostController(
         postModel as Model<PostStructure>,
       );
@@ -85,7 +85,7 @@ describe("Given the getPostById method of PostController", () => {
 
   describe("When you receive a request with id of Cocido Madrileño that doesn't exist in the database", () => {
     const req = {
-      params: { postId: "cocidomadrileñoriquisimo" },
+      params: { postId: "987034567248930654289054" },
     } as Pick<Request, "params">;
 
     const postModel: Pick<Model<PostStructure>, "findById"> = {

--- a/src/post/router/__tests__/getPostByIdEndpoint.test.ts
+++ b/src/post/router/__tests__/getPostByIdEndpoint.test.ts
@@ -21,8 +21,8 @@ afterEach(async () => {
   await server.stop();
 });
 
-describe("Given the GET/posts/123456789123456789123456 endpoint", () => {
-  describe("When it receives a request", () => {
+describe("Given the GET/posts/:id endpoint", () => {
+  describe("When it receives a request with /posts/123456789123456789123456", () => {
     test("Then it should respond with a 200 status code and Carne para titanes hambrientos 🍖🛡️ post", async () => {
       await Post.create(attackOnTitanMeatPost, bleachSushiPost);
 
@@ -39,24 +39,20 @@ describe("Given the GET/posts/123456789123456789123456 endpoint", () => {
       );
     });
   });
-});
 
-describe("Given the GET/posts/000 endpoint", () => {
-  describe("When it receives a request", () => {
-    test("Then it should respond with a 406 status code and a 'Not valid id' error message", async () => {
+  describe("When it receives a request with /posts/000 invalid and non existent id", () => {
+    test("Then it should respond with a 400 status code and a 'Not valid id' error message", async () => {
       await Post.create(attackOnTitanMeatPost, bleachSushiPost);
 
       const response = await request(app).get("/posts/000");
       const body = response.body as { error: string };
 
-      expect(response.status).toBe(406);
+      expect(response.status).toBe(400);
       expect(body.error).toBe("Id not valid");
     });
   });
-});
 
-describe("Given the GET/posts/573561324567825367892345 non existing post id endpoint", () => {
-  describe("When it receives a request", () => {
+  describe("When it receives a request with /posts/573561324567825367892345 non existent id", () => {
     test("Then it should respond with a 404 status code and a 'Post not found' error message", async () => {
       await Post.create(attackOnTitanMeatPost, bleachSushiPost);
 


### PR DESCRIPTION
Use isValidObjectId function from mongoose instead of the id length and the fix delete and get post by id controller and endpoint broken tests.